### PR TITLE
Use magic_enum for default enum value in help menu

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -94,6 +94,14 @@ namespace argparse {
 #elif defined(_MSC_VER)
 #pragma warning(pop)
 #endif
+#ifdef HAS_MAGIC_ENUM
+        } else if constexpr (std::is_enum<T>::value) {
+            for (const auto &[name, value] : magic_enum::enum_entries<T>()) {
+                if (v == name) {
+                    return std::string{ value };
+                }
+            }
+#endif
         } else if constexpr (has_ostream_operator<T>::value) {
             return static_cast<std::ostringstream &&>((std::ostringstream() << std::boolalpha << v)).str();       // https://github.com/stan-dev/math/issues/590#issuecomment-550122627
         } else {


### PR DESCRIPTION
Currently the default value for enum types gets displayed as an integer. magic_enum can be used to make the help print out a little more clear.